### PR TITLE
Add 2021 framework evaluation notes (Atavism, uMMORPG) to Research Archive

### DIFF
--- a/index.html
+++ b/index.html
@@ -809,6 +809,22 @@
 
         <article class="project">
           <div class="project-head">
+            <h3>Framework Evaluation Notes (c. 2021)</h3>
+            <span class="project-role">Atavism &middot; uMMORPG</span>
+          </div>
+          <div class="stack">
+            <span class="tag tag-primary">Atavism Online</span>
+            <span class="tag">uMMORPG</span>
+            <span class="tag">Unity</span>
+            <span class="tag">Java</span>
+          </div>
+          <p>Before committing to an in-house engine, we briefly evaluated <a href="https://www.atavismonline.com/" target="_blank" rel="noopener">Atavism Online</a> as a possible foundation for Pirate Raids Online, and weighed it against <a href="https://assetstore.unity.com/packages/templates/systems/ummorpg-51212" target="_blank" rel="noopener">uMMORPG</a> as the lighter-weight alternative on the Unity Asset Store. uMMORPG was appealing for its simplicity and full source access, but Atavism&rsquo;s server architecture was the stronger of the two for what we had in mind: modular, royalty-free at the time, and feature-rich relative to the Tales of Pirates / Pirate King Online baseline we were working from. Open questions that ultimately steered us away from Atavism included the long-term licensing posture (perpetual vs. subscription, $500 perma vs. $29/mo trial paths), CCU scaling beyond ~1,000 concurrents, and the depth of access to the Java server internals.</p>
+          <p>Reference material we collected during the review: the <a href="https://www.atavismonline.com/made-with-atavism" target="_blank" rel="noopener">Atavism showcase reel</a>, shipped titles such as <a href="http://arcfall.com/" target="_blank" rel="noopener">Arcfall</a> and <a href="https://www.worldofheroes.pl/" target="_blank" rel="noopener">World of Heroes</a>, a <a href="https://youtu.be/PDE4HtuQwhI" target="_blank" rel="noopener">creator interview</a>, and <a href="https://pyre.gg/minimum-requirements-to-run-atavism-mmo-creator-on-pc" target="_blank" rel="noopener">pyre.gg&rsquo;s server-requirements writeup</a>.</p>
+          <p>Our take: either stack is a viable way to get an MVP on its feet quickly and prove the gameplay loop, but you should adopt one knowing you will eventually need a migration plan off it. Licensing terms can shift, CCU ceilings become real once a community forms, and the engine <em>is</em> the game once you pass a certain depth. Start on Atavism (or uMMORPG) if it shortens the runway to a playable build; just don&rsquo;t let &ldquo;temporary&rdquo; become &ldquo;permanent&rdquo; by accident.</p>
+        </article>
+
+        <article class="project">
+          <div class="project-head">
             <h3><a href="https://github.com/Dytomic/top-forums-archive" target="_blank" rel="noopener">top-forums-archive &rarr;</a></h3>
             <span class="project-role">3 Forums &middot; Community Archive</span>
           </div>

--- a/llms.txt
+++ b/llms.txt
@@ -49,6 +49,10 @@ Three repositories preserve the studio's engine research:
 - [pkodev-Perseus](https://github.com/Dytomic/pkodev-Perseus): 6 TOP/PKO server infrastructure and CMS projects by community developer Perseus mirrored as git subtrees. Rust (GateServer rewrite, DDoS proxy), Go (comms), PHP/Laravel (portal), JS (CMS).
 - [top-forums-archive](https://github.com/Dytomic/top-forums-archive): Preserved snapshots of three Tales of Pirates / PKO community forums totalling 1,683 threads: pkodev.com (166 threads), forum.ragezone.com (1,350 threads across 5 sections), and go-piratia.ru (167 threads, Russian). Each forum is stored in both original HTML and Markdown under its own folder in the repo ([pkodev](https://github.com/Dytomic/top-forums-archive/tree/main/pkodev), [ragezone](https://github.com/Dytomic/top-forums-archive/tree/main/ragezone), [gopiratia](https://github.com/Dytomic/top-forums-archive/tree/main/gopiratia)).
 
+## Framework evaluation notes (c. 2021)
+
+Before committing to an in-house engine, the studio briefly evaluated [Atavism Online](https://www.atavismonline.com/) as a possible foundation for Pirate Raids Online, and weighed it against [uMMORPG](https://assetstore.unity.com/packages/templates/systems/ummorpg-51212) as the lighter-weight Unity Asset Store alternative. Atavism's server architecture was the stronger of the two: modular, royalty-free at the time, and feature-rich relative to the Tales of Pirates / Pirate King Online baseline. Open questions that steered the studio away from Atavism included long-term licensing posture (perpetual vs. subscription, $500 perma vs. $29/mo trial paths), CCU scaling beyond ~1,000 concurrents, and depth of access to the Java server internals. Either stack is a viable way to reach an MVP quickly, but should be adopted with an explicit migration plan in mind: licensing terms can shift, CCU ceilings become real once a community forms, and the engine is effectively the game past a certain depth.
+
 ## Pirate Raids Online details
 
 - **Playable races:** Dwarves, Triton, Runeborne, Amazonians (four Demigod tribes)


### PR DESCRIPTION
## Summary
- Adds a new article block to the Research Archive section of `index.html` capturing the studio's c. 2021 evaluation of Atavism Online vs. uMMORPG before committing to the in-house engine.
- Adds a matching `## Framework evaluation notes (c. 2021)` section to `llms.txt` so the LLM-facing summary stays in sync with the site.
- Includes the reference material gathered during the review (Atavism showcase reel, Arcfall, World of Heroes, creator interview, pyre.gg server-requirements writeup) and the takeaway that either stack is viable for an MVP provided a migration plan is in place from day one.

## Test plan
- [ ] Open `index.html` locally and confirm the new article renders cleanly inside the Research Archive `shadow-box`, between the Perseus and top-forums-archive blocks.
- [ ] Verify the four outbound links (atavismonline, arcfall, worldofheroes, youtu.be, pyre.gg) all resolve.
- [ ] Confirm `llms.txt` parses as valid Markdown and the new section sits between the TOP/PKO archive list and the Pirate Raids Online details block.
- [ ] After merge, spot-check https://dytomic.github.io/#research once Pages redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)